### PR TITLE
More restrictive dependencies for maven

### DIFF
--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -20,7 +20,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
+      <artifactId>maven-model</artifactId>
       <version>${maven.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Maybe there is a need for including all maven-core, but I couldn't find it in my use case utilizing mmm java maven.
Possibly it's worth thinking about replacing maven-core with maven-model dependency if the rest of maven-core is not needed.