### PR TITLE
fixing maven.config interpretation

### DIFF
--- a/java/maven/src/main/java/net/sf/mmm/code/java/maven/impl/MavenBridgeImpl.java
+++ b/java/maven/src/main/java/net/sf/mmm/code/java/maven/impl/MavenBridgeImpl.java
@@ -213,25 +213,33 @@ public class MavenBridgeImpl implements MavenBridge, MavenConstants {
 
   private Properties resolveProperties(Properties properties, File projectBaseDir) {
 
-    try {
-      File mvnDir = new File(projectBaseDir, ".mvn");
-      if (mvnDir.isDirectory()) {
-        File mvnConfig = new File(mvnDir, "maven.config");
-        if (mvnConfig.isFile()) {
-          properties = new Properties(properties);
-          List<String> lines = Files.readAllLines(mvnConfig.toPath());
-          for (String line : lines) {
-            resolveProperties(properties, line.trim());
+    if (projectBaseDir.getParentFile() == null) {
+      return properties;
+    }
+
+    boolean pomFileExists = new File(projectBaseDir, POM_XML).exists();
+    boolean parentPomFileExists = new File(projectBaseDir.getParentFile(), POM_XML).exists();
+    if (pomFileExists && !parentPomFileExists) {
+      return properties; // found "project's top level directory"
+    } else if (pomFileExists) {
+      try {
+        File mvnDir = new File(projectBaseDir, ".mvn");
+        if (mvnDir.isDirectory()) {
+          File mvnConfig = new File(mvnDir, "maven.config");
+          if (mvnConfig.isFile()) {
+            properties = new Properties(properties);
+            List<String> lines = Files.readAllLines(mvnConfig.toPath());
+            for (String line : lines) {
+              resolveProperties(properties, line.trim());
+            }
           }
         }
+        return resolveProperties(properties, projectBaseDir.getParentFile());
+      } catch (IOException e) {
+        throw new IllegalStateException("Error reading maven.config from " + projectBaseDir, e);
       }
-      File parent = projectBaseDir.getParentFile();
-      if (parent != null) {
-        return resolveProperties(properties, parent);
-      }
-      return properties;
-    } catch (IOException e) {
-      throw new IllegalStateException("Error reading maven.config from " + projectBaseDir, e);
+    } else {
+      return resolveProperties(properties, projectBaseDir.getParentFile());
     }
   }
 

--- a/java/maven/src/main/java/net/sf/mmm/code/java/maven/impl/MavenBridgeImpl.java
+++ b/java/maven/src/main/java/net/sf/mmm/code/java/maven/impl/MavenBridgeImpl.java
@@ -227,7 +227,6 @@ public class MavenBridgeImpl implements MavenBridge, MavenConstants {
         if (mvnDir.isDirectory()) {
           File mvnConfig = new File(mvnDir, "maven.config");
           if (mvnConfig.isFile()) {
-            properties = new Properties(properties);
             List<String> lines = Files.readAllLines(mvnConfig.toPath());
             for (String line : lines) {
               resolveProperties(properties, line.trim());

--- a/java/maven/src/main/java/net/sf/mmm/code/java/maven/impl/MavenBridgeImpl.java
+++ b/java/maven/src/main/java/net/sf/mmm/code/java/maven/impl/MavenBridgeImpl.java
@@ -220,8 +220,7 @@ public class MavenBridgeImpl implements MavenBridge, MavenConstants {
     boolean pomFileExists = new File(projectBaseDir, POM_XML).exists();
     boolean parentPomFileExists = new File(projectBaseDir.getParentFile(), POM_XML).exists();
     if (pomFileExists && !parentPomFileExists) {
-      return properties; // found "project's top level directory"
-    } else if (pomFileExists) {
+      // found "project's top level directory"
       try {
         File mvnDir = new File(projectBaseDir, ".mvn");
         if (mvnDir.isDirectory()) {


### PR DESCRIPTION
There is a misleading implementation of resolveProperties, which actually searches until `/` dir of .mvn folders and implementing the logic, that most top level maven.config properties will overturn nearest once. Nonetheless, there is nothing like that specified in the documents of maven: https://maven.apache.org/configure.html#mvn-directory 
For each project, there is just one `.mvn` folder on the "project's top level directory". Therefore, I re-implemented the method to just scan from the input File dir up to the top level pom.xml, which does not have any further parent directory coming with another pom.xml. Only the `.mvn` folder in this top level project directory will be taking into account. If there is no further `pom.xml` in the next parent, we will stop with the recursion to not end up in accidentally interpreting more top level `.mvn` folders.